### PR TITLE
Fix impurity density not being stored in SI units

### DIFF
--- a/imas/interface/dina_params_imas.f90
+++ b/imas/interface/dina_params_imas.f90
@@ -303,7 +303,7 @@ call xml2eg_get(doc, 'tt_dina', tt_dina_c)
            nz_imp_c4 = psch%density_control%ion(ion)%element(1)%z_n
            n_t_c4 = size(psch%density_control%ion(ion)%n_i_volume_average%reference%time)
            t_t_c4(1:n_t_c4) = psch%density_control%ion(ion)%n_i_volume_average%reference%time(1:n_t_c4)*1.d3
-           pn_d_t_c4(1:n_t_c4) = psch%density_control%ion(ion)%n_i_volume_average%reference%data(1:n_t_c4)
+           pn_d_t_c4(1:n_t_c4) = psch%density_control%ion(ion)%n_i_volume_average%reference%data(1:n_t_c4)*1.d-19
         
         
 !           open (unit=41,file='gamma_z2.dat',form='formatted') 
@@ -319,7 +319,7 @@ call xml2eg_get(doc, 'tt_dina', tt_dina_c)
            nz_imp2_c5 = psch%density_control%ion(ion)%element(1)%z_n
            n_t_c5 = size(psch%density_control%ion(ion)%n_i_volume_average%reference%time)
            t_t_c5(1:n_t_c5) = psch%density_control%ion(ion)%n_i_volume_average%reference%time(1:n_t_c5)*1.d3
-           pn_d_t_c5(1:n_t_c5) = psch%density_control%ion(ion)%n_i_volume_average%reference%data(1:n_t_c5)
+           pn_d_t_c5(1:n_t_c5) = psch%density_control%ion(ion)%n_i_volume_average%reference%data(1:n_t_c5)*1.d-19
         
         
 !	open (unit=41,file='init.dat',form='formatted')
@@ -377,7 +377,7 @@ call xml2eg_get(doc, 'gain_puff', g_gain_c6)
            nz_imp1_c9 = psch%density_control%ion(ion)%element(1)%z_n
            n_t_c9 = size(psch%density_control%ion(ion)%n_i_volume_average%reference%time)
            t_t_c9(1:n_t_c9) = psch%density_control%ion(ion)%n_i_volume_average%reference%time(1:n_t_c9)*1.d3
-           pn_d_t_c9(1:n_t_c9) = psch%density_control%ion(ion)%n_i_volume_average%reference%data(1:n_t_c9)
+           pn_d_t_c9(1:n_t_c9) = psch%density_control%ion(ion)%n_i_volume_average%reference%data(1:n_t_c9)*1.d-19
         
 !           open (unit=41,file='gamma_z3.dat',form='formatted') 
            !read (49,*) 
@@ -392,7 +392,7 @@ call xml2eg_get(doc, 'gain_puff', g_gain_c6)
            nz_imp3_c10 = psch%density_control%ion(ion)%element(1)%z_n
            n_t_c10 = size(psch%density_control%ion(ion)%n_i_volume_average%reference%time)
            t_t_c10(1:n_t_c10) = psch%density_control%ion(ion)%n_i_volume_average%reference%time(1:n_t_c10)*1.d3
-           pn_d_t_c10(1:n_t_c10) = psch%density_control%ion(ion)%n_i_volume_average%reference%data(1:n_t_c10)
+           pn_d_t_c10(1:n_t_c10) = psch%density_control%ion(ion)%n_i_volume_average%reference%data(1:n_t_c10)*1.d-19
         
         
 !           open (unit=41,file='gamma_z4.dat',form='formatted') 
@@ -408,7 +408,7 @@ call xml2eg_get(doc, 'gain_puff', g_gain_c6)
            nz_imp4_c11 = psch%density_control%ion(ion)%element(1)%z_n
            n_t_c11 = size(psch%density_control%ion(ion)%n_i_volume_average%reference%time)
            t_t_c11(1:n_t_c11) = psch%density_control%ion(ion)%n_i_volume_average%reference%time(1:n_t_c11)*1.d3
-           pn_d_t_c11(1:n_t_c11) = psch%density_control%ion(ion)%n_i_volume_average%reference%data(1:n_t_c11)
+           pn_d_t_c11(1:n_t_c11) = psch%density_control%ion(ion)%n_i_volume_average%reference%data(1:n_t_c11)*1.d-19
         
 !                 open (unit=41,file='bohm_gbohm.dat',form='formatted')
                 !read (49,*)

--- a/imas/iwrap/dina_imas/dina_params_imas.f90
+++ b/imas/iwrap/dina_imas/dina_params_imas.f90
@@ -305,7 +305,7 @@ call xml2eg_get(doc, 'tt_dina', tt_dina_c)
            nz_imp_c4 = psch%density_control%ion(ion)%element(1)%z_n
            n_t_c4 = size(psch%density_control%ion(ion)%n_i_volume_average%reference%time)
            t_t_c4(1:n_t_c4) = psch%density_control%ion(ion)%n_i_volume_average%reference%time(1:n_t_c4)*1.d3
-           pn_d_t_c4(1:n_t_c4) = psch%density_control%ion(ion)%n_i_volume_average%reference%data(1:n_t_c4)
+           pn_d_t_c4(1:n_t_c4) = psch%density_control%ion(ion)%n_i_volume_average%reference%data(1:n_t_c4)*1.d-19
         
         
 !           open (unit=41,file='gamma_z2.dat',form='formatted') 
@@ -321,7 +321,7 @@ call xml2eg_get(doc, 'tt_dina', tt_dina_c)
            nz_imp2_c5 = psch%density_control%ion(ion)%element(1)%z_n
            n_t_c5 = size(psch%density_control%ion(ion)%n_i_volume_average%reference%time)
            t_t_c5(1:n_t_c5) = psch%density_control%ion(ion)%n_i_volume_average%reference%time(1:n_t_c5)*1.d3
-           pn_d_t_c5(1:n_t_c5) = psch%density_control%ion(ion)%n_i_volume_average%reference%data(1:n_t_c5)
+           pn_d_t_c5(1:n_t_c5) = psch%density_control%ion(ion)%n_i_volume_average%reference%data(1:n_t_c5)*1.d-19
         
         
 !	open (unit=41,file='init.dat',form='formatted')
@@ -379,7 +379,7 @@ call xml2eg_get(doc, 'gain_puff', g_gain_c6)
            nz_imp1_c9 = psch%density_control%ion(ion)%element(1)%z_n
            n_t_c9 = size(psch%density_control%ion(ion)%n_i_volume_average%reference%time)
            t_t_c9(1:n_t_c9) = psch%density_control%ion(ion)%n_i_volume_average%reference%time(1:n_t_c9)*1.d3
-           pn_d_t_c9(1:n_t_c9) = psch%density_control%ion(ion)%n_i_volume_average%reference%data(1:n_t_c9)
+           pn_d_t_c9(1:n_t_c9) = psch%density_control%ion(ion)%n_i_volume_average%reference%data(1:n_t_c9)*1.d-19
         
 !           open (unit=41,file='gamma_z3.dat',form='formatted') 
            !read (49,*) 
@@ -394,7 +394,7 @@ call xml2eg_get(doc, 'gain_puff', g_gain_c6)
            nz_imp3_c10 = psch%density_control%ion(ion)%element(1)%z_n
            n_t_c10 = size(psch%density_control%ion(ion)%n_i_volume_average%reference%time)
            t_t_c10(1:n_t_c10) = psch%density_control%ion(ion)%n_i_volume_average%reference%time(1:n_t_c10)*1.d3
-           pn_d_t_c10(1:n_t_c10) = psch%density_control%ion(ion)%n_i_volume_average%reference%data(1:n_t_c10)
+           pn_d_t_c10(1:n_t_c10) = psch%density_control%ion(ion)%n_i_volume_average%reference%data(1:n_t_c10)*1.d-19
         
         
 !           open (unit=41,file='gamma_z4.dat',form='formatted') 
@@ -410,7 +410,7 @@ call xml2eg_get(doc, 'gain_puff', g_gain_c6)
            nz_imp4_c11 = psch%density_control%ion(ion)%element(1)%z_n
            n_t_c11 = size(psch%density_control%ion(ion)%n_i_volume_average%reference%time)
            t_t_c11(1:n_t_c11) = psch%density_control%ion(ion)%n_i_volume_average%reference%time(1:n_t_c11)*1.d3
-           pn_d_t_c11(1:n_t_c11) = psch%density_control%ion(ion)%n_i_volume_average%reference%data(1:n_t_c11)
+           pn_d_t_c11(1:n_t_c11) = psch%density_control%ion(ion)%n_i_volume_average%reference%data(1:n_t_c11)*1.d-19
         
 !                 open (unit=41,file='bohm_gbohm.dat',form='formatted')
                 !read (49,*)

--- a/tools/GUI/main.py
+++ b/tools/GUI/main.py
@@ -2270,7 +2270,7 @@ class ExampleApp(uiclass, baseclass):
       #print('Be waveform for 0D, z='+str(z))
       #print(record)
       self.FillIonElement(psch.density_control.ion[ion], record.z)
-      self.FillPulseScheduleItem(psch.density_control.ion[ion].n_i_volume_average.reference, record)
+      self.FillPulseScheduleItem(psch.density_control.ion[ion].n_i_volume_average.reference, record, mult=1.e19)
       
       # Be content (1D transport)
       record = self.generalData['gamma_z1'] #self.GetStuctWithFieldValue(self.generalData, "title", "gamma_z1.dat")
@@ -2278,25 +2278,25 @@ class ExampleApp(uiclass, baseclass):
       #print('Be waveform for 1D, z='+str(z))
       #print(record)
       self.FillIonElement(psch.density_control.ion[ion], record.z)
-      self.FillPulseScheduleItem(psch.density_control.ion[ion].n_i_volume_average.reference, record)
+      self.FillPulseScheduleItem(psch.density_control.ion[ion].n_i_volume_average.reference, record, mult=1.e19)
       
       # W content
       record = self.generalData['gamma_z2'] #self.GetStuctWithFieldValue(self.generalData, "title", "gamma_z2.dat")
       ion = 4
       self.FillIonElement(psch.density_control.ion[ion], record.z)
-      self.FillPulseScheduleItem(psch.density_control.ion[ion].n_i_volume_average.reference, record)
+      self.FillPulseScheduleItem(psch.density_control.ion[ion].n_i_volume_average.reference, record, mult=1.e19)
        
       # Ar content
       record = self.generalData['gamma_z3'] #self.GetStuctWithFieldValue(self.generalData, "title", "gamma_z3.dat")
       ion = 5
       self.FillIonElement(psch.density_control.ion[ion], record.z)
-      self.FillPulseScheduleItem(psch.density_control.ion[ion].n_i_volume_average.reference, record)
+      self.FillPulseScheduleItem(psch.density_control.ion[ion].n_i_volume_average.reference, record, mult=1.e19)
       
       # Ne content
       record = self.generalData['gamma_z4'] #self.GetStuctWithFieldValue(self.generalData, "title", "gamma_z4.dat")
       ion = 6
       self.FillIonElement(psch.density_control.ion[ion], record.z)
-      self.FillPulseScheduleItem(psch.density_control.ion[ion].n_i_volume_average.reference, record)
+      self.FillPulseScheduleItem(psch.density_control.ion[ion].n_i_volume_average.reference, record, mult=1.e19)
  
  
       # Aux heating


### PR DESCRIPTION
This commit fixes wrong conversions for the five impurity ion densities, so that they are stored and retrieved as #/m3 instead of 1e19/m3.

DINA GUI can load variables from DINA's *.dat input files and store them in the IDS format. However, while main ion density is correctly converted to SI units when it is stored in the IDS, impurity ion densities were not.

Although #2 mentions that there seems to be no treatment of tritium ion density, there is in fact code in dina_params_imas.f90 routine which converts and stores tritium ion density in SI units. It appears a few lines below the part treating deuterium ion density, where one would not normally expect it to be.

Users will need to run DINA GUI again and re-generate input IDSs if they want to replicate previous DINA-PS runs. DINA inputs in *.dat files does not have to be changed.

Closes: #2